### PR TITLE
Add admin bulk email feature

### DIFF
--- a/app/api/admin/page.tsx
+++ b/app/api/admin/page.tsx
@@ -7,6 +7,9 @@ export default function AdminDashboard() {
   const [auth, setAuth] = useState(false)
   const [slug, setSlug] = useState(Object.keys(products)[0])
   const [purchases, setPurchases] = useState([])
+  const [subject, setSubject] = useState("")
+  const [message, setMessage] = useState("")
+  const [status, setStatus] = useState("")
 
   useEffect(() => {
     const key = prompt("Enter admin secret:")
@@ -28,6 +31,23 @@ export default function AdminDashboard() {
 
     fetchPurchases()
   }, [slug, auth])
+
+  const sendEmail = async () => {
+    setStatus("Sending...")
+    const res = await fetch(`/api/admin/send-email?secret=${process.env.NEXT_PUBLIC_ADMIN_SECRET}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ slug, subject, message }),
+    })
+    const data = await res.json()
+    if (data.success) {
+      setStatus(`Sent to ${data.count} recipients`)
+      setSubject("")
+      setMessage("")
+    } else {
+      setStatus(data.error || "Error sending")
+    }
+  }
 
   if (!auth) return null
 
@@ -56,6 +76,29 @@ export default function AdminDashboard() {
           </li>
         ))}
       </ul>
+
+      <div className="mt-8 space-y-2">
+        <input
+          className="w-full bg-black text-white border border-gray-500 rounded px-4 py-2"
+          placeholder="Subject"
+          value={subject}
+          onChange={(e) => setSubject(e.target.value)}
+        />
+        <textarea
+          className="w-full bg-black text-white border border-gray-500 rounded px-4 py-2"
+          rows={4}
+          placeholder="Message HTML"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+        />
+        <button
+          onClick={sendEmail}
+          className="bg-yellow-500 text-black font-semibold px-4 py-2 rounded"
+        >
+          Send Email to Buyers
+        </button>
+        {status && <p className="text-sm mt-2">{status}</p>}
+      </div>
     </div>
   )
 }

--- a/app/api/admin/send-email/route.ts
+++ b/app/api/admin/send-email/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import { sendCustomEmail } from "@/lib/email"
+
+export async function POST(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const secret = searchParams.get("secret")
+
+  if (secret !== process.env.NEXT_PUBLIC_ADMIN_SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const { slug, subject, message } = await req.json()
+
+  if (!slug || !subject || !message) {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 })
+  }
+
+  const purchases = await prisma.purchase.findMany({
+    where: { productSlug: slug },
+    select: { email: true },
+  })
+
+  const emails = Array.from(new Set(purchases.map((p) => p.email)))
+
+  for (const email of emails) {
+    await sendCustomEmail(email, subject, message)
+  }
+
+  return NextResponse.json({ success: true, count: emails.length })
+}

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -46,3 +46,21 @@ export async function sendDownloadEmail(
     `,
   });
 }
+
+export async function sendCustomEmail(to: string, subject: string, html: string) {
+  if (process.env.NODE_ENV === "development") {
+    console.log(`[DEV] Skipping custom email to ${to} with subject ${subject}`)
+    return
+  }
+
+  if (!process.env.EMAIL_USER) {
+    throw new Error("Missing required environment variables.")
+  }
+
+  await transporter.sendMail({
+    from: `"DeepDigiDive" <${process.env.EMAIL_USER}>`,
+    to,
+    subject,
+    html,
+  })
+}


### PR DESCRIPTION
## Summary
- support sending custom emails to all buyers of a product
- expose new `/api/admin/send-email` API endpoint
- extend admin dashboard UI with form to send emails
- general-purpose `sendCustomEmail` helper

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685701f986248330941b2a92edc9e802