### PR TITLE
Refactor Stripe webhook handling

### DIFF
--- a/app/api/stripe/webhook/route.tsx
+++ b/app/api/stripe/webhook/route.tsx
@@ -1,70 +1,6 @@
-// // app/api/stripe/webhook/route.ts
-// import { NextResponse } from "next/server"
-// import Stripe from "stripe"
-// import { buffer } from "micro"
-// import nodemailer from "nodemailer"
-// import { sendDownloadEmail } from "@/lib/email"
-
-
-// await transporter.sendMail({
-//   from: `"Deep Digi Dive" <${process.env.EMAIL_USER}>`,
-//   to,
-//   subject: "Your Digital Product is Ready!",
-//   html: `
-//       <p>Hi there,</p>
-//       <p>Thank you for your purchase. Click below to download:</p>
-//       <a href="${process.env.NEXT_PUBLIC_SITE_URL}/downloads/${slug}.pdf">Download Now</a>
-//       <p>Enjoy and feel free to reach out anytime.</p>
-//       <p>– The Deep Digi Dive Team</p>
-//     `,
-// })
-
-
-// const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-//   apiVersion: "2023-10-16",
-// })
-
-// export const config = {
-//   api: {
-//     bodyParser: false,
-//   },
-// }
-
-// export async function POST(req: Request) {
-//   const rawBody = await req.arrayBuffer()
-//   const signature = req.headers.get("stripe-signature") as string
-
-//   let event: Stripe.Event
-
-//   try {
-//     event = stripe.webhooks.constructEvent(
-//       Buffer.from(rawBody),
-//       signature,
-//       process.env.STRIPE_WEBHOOK_SECRET!
-//     )
-//   } catch (err) {
-//     console.error("Webhook signature verification failed.", err)
-//     return new NextResponse("Invalid signature", { status: 400 })
-//   }
-
-//   if (event.type === "checkout.session.completed") {
-//     const session = event.data.object as Stripe.Checkout.Session
-//     const email = session.customer_details?.email
-//     const slug = session.metadata?.slug
-
-//     if (email && slug) {
-//       await sendDownloadEmail(email, product.name, slug)
-//     }
-//   }
-
-//   return new NextResponse("OK", { status: 200 })
-// }
-// app/api/stripe/webhook/route.ts
 import { NextRequest, NextResponse } from "next/server"
 import Stripe from "stripe"
-import { buffer } from "micro"
-import { sendDownloadEmail } from "@/lib/email"
-import { PrismaClient } from "@prisma/client"
+import { logPurchase } from "@/lib/purchase"
 
 export const config = {
   api: {
@@ -72,25 +8,29 @@ export const config = {
   },
 }
 
+const stripeSecret = process.env.STRIPE_SECRET_KEY
+const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET
 
-const prisma = new PrismaClient()
+if (!stripeSecret || !webhookSecret) {
+  throw new Error("Stripe environment variables are not set")
+}
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+const stripe = new Stripe(stripeSecret, {
   apiVersion: "2025-05-28.basil",
 })
 
 export async function POST(req: NextRequest) {
   const rawBody = await req.arrayBuffer()
-  const signature = req.headers.get("stripe-signature") as string
+  const signature = req.headers.get("stripe-signature")
+
+  if (!signature) {
+    return new NextResponse("Missing signature", { status: 400 })
+  }
 
   let event: Stripe.Event
 
   try {
-    event = stripe.webhooks.constructEvent(
-      Buffer.from(rawBody),
-      signature,
-      process.env.STRIPE_WEBHOOK_SECRET!
-    )
+    event = stripe.webhooks.constructEvent(Buffer.from(rawBody), signature, webhookSecret)
   } catch (err) {
     console.error("Webhook signature verification failed.", err)
     return new NextResponse("Invalid signature", { status: 400 })
@@ -98,25 +38,14 @@ export async function POST(req: NextRequest) {
 
   if (event.type === "checkout.session.completed") {
     const session = event.data.object as Stripe.Checkout.Session
-    const email = session.customer_details?.email
-    const slug = session.metadata?.slug
 
-    console.log("✅ Payment received for:", email, "slug:", slug)
-
-    if (email && slug) {
-      await prisma.purchase.create({
-        data: {
-          email,
-          productSlug: slug,
-          fullName: session.customer_details?.name || "",
-          phone: session.customer_details?.phone || "",
-          type: slug.includes("course") ? "course" : "ebook", // example logic
-        },
+    if (session.customer_details?.email && session.metadata?.slug) {
+      await logPurchase(session.customer_details.email, session.metadata.slug, {
+        name: session.customer_details.name || "",
+        phone: session.customer_details.phone || "",
       })
-
-      await sendDownloadEmail(email, slug, slug)
     }
   }
 
-  return new NextResponse("Webhook received", { status: 200 })
+  return new NextResponse(null, { status: 200 })
 }

--- a/lib/purchase.ts
+++ b/lib/purchase.ts
@@ -1,0 +1,16 @@
+import { prisma } from "@/lib/prisma";
+import { sendDownloadEmail } from "@/lib/email";
+
+export async function logPurchase(email: string, slug: string, opts?: { name?: string; phone?: string }) {
+  await prisma.purchase.create({
+    data: {
+      email,
+      productSlug: slug,
+      fullName: opts?.name ?? "",
+      phone: opts?.phone ?? "",
+      type: slug.includes("course") ? "course" : "ebook",
+    },
+  });
+
+  await sendDownloadEmail(email, slug, slug, opts?.phone);
+}


### PR DESCRIPTION
## Summary
- extract purchase creation and email sending to `lib/purchase.ts`
- clean up and simplify `app/api/stripe/webhook/route.tsx`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a42723db88330a7c4fb210875e260