### PR TITLE
Implement dummy purchase flow

### DIFF
--- a/app/api/stripe/webhook/route.tsx
+++ b/app/api/stripe/webhook/route.tsx
@@ -1,51 +1,7 @@
-import { NextRequest, NextResponse } from "next/server"
-import Stripe from "stripe"
-import { logPurchase } from "@/lib/purchase"
+import { NextResponse } from "next/server"
 
-export const config = {
-  api: {
-    bodyParser: false, // Needed to prevent body from being parsed!
-  },
-}
-
-const stripeSecret = process.env.STRIPE_SECRET_KEY
-const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET
-
-if (!stripeSecret || !webhookSecret) {
-  throw new Error("Stripe environment variables are not set")
-}
-
-const stripe = new Stripe(stripeSecret, {
-  apiVersion: "2025-05-28.basil",
-})
-
-export async function POST(req: NextRequest) {
-  const rawBody = await req.arrayBuffer()
-  const signature = req.headers.get("stripe-signature")
-
-  if (!signature) {
-    return new NextResponse("Missing signature", { status: 400 })
-  }
-
-  let event: Stripe.Event
-
-  try {
-    event = stripe.webhooks.constructEvent(Buffer.from(rawBody), signature, webhookSecret)
-  } catch (err) {
-    console.error("Webhook signature verification failed.", err)
-    return new NextResponse("Invalid signature", { status: 400 })
-  }
-
-  if (event.type === "checkout.session.completed") {
-    const session = event.data.object as Stripe.Checkout.Session
-
-    if (session.customer_details?.email && session.metadata?.slug) {
-      await logPurchase(session.customer_details.email, session.metadata.slug, {
-        name: session.customer_details.name || "",
-        phone: session.customer_details.phone || "",
-      })
-    }
-  }
-
-  return new NextResponse(null, { status: 200 })
+// Stripe webhook is disabled in dummy payment mode.
+export async function POST() {
+  console.log("Webhook stubbed")
+  return NextResponse.json({ ok: true })
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,6 +38,11 @@ export default function RootLayout({
         <div className="relative group max-w-6xl mx-auto">
             <Header />
             <Toaster position="top-center" />
+            {process.env.DUMMY_PAYMENT_MODE === "true" && (
+              <div className="bg-red-600 text-center text-sm py-2">
+                Payments are simulated for testing. No real transaction is made.
+              </div>
+            )}
             
             {/* App content */}
             <main>

--- a/app/products/[slug]/page.tsx
+++ b/app/products/[slug]/page.tsx
@@ -59,18 +59,14 @@ export default function ProductPage() {
     setLoading(true)
 
     try {
-      const res = await fetch("/api/checkout", {
+      await fetch("/api/checkout", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ slug }),
       })
 
-      const data = await res.json()
-      if (data.url) {
-        window.location.href = data.url
-      } else {
-        alert("Something went wrong.")
-      }
+      // In dummy mode we simply redirect to the thank-you page
+      window.location.href = `/thank-you/${slug}`
     } catch (err) {
       console.error("Checkout error:", err)
       alert("Failed to start checkout.")


### PR DESCRIPTION
## Summary
- simulate purchases in `/api/checkout`
- disable the Stripe webhook
- add warning banner for dummy mode
- update product page checkout logic

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685a4a87921483309cee105569befc05