### PR TITLE
Add dynamic email templates and logging

### DIFF
--- a/app/admin/emails/page.tsx
+++ b/app/admin/emails/page.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useEffect, useState } from "react"
+
+export default function EmailLogPage() {
+  const [auth, setAuth] = useState(false)
+  const [logs, setLogs] = useState<any[]>([])
+
+  useEffect(() => {
+    const key = prompt('Enter admin secret:')
+    if (key === process.env.NEXT_PUBLIC_ADMIN_SECRET) {
+      setAuth(true)
+    } else {
+      alert('Unauthorized')
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!auth) return
+    const fetchLogs = async () => {
+      const res = await fetch(`/api/admin/email-logs?secret=${process.env.NEXT_PUBLIC_ADMIN_SECRET}`)
+      const data = await res.json()
+      setLogs(data.logs || [])
+    }
+    fetchLogs()
+  }, [auth])
+
+  if (!auth) return null
+
+  return (
+    <div className="p-6 text-white">
+      <h1 className="text-2xl font-bold mb-4">📧 Email Send Log</h1>
+      <ul className="space-y-2">
+        {logs.map(log => (
+          <li key={log.id} className="bg-[#1f1f2e] p-4 rounded-md">
+            <p><strong>Email:</strong> {log.email}</p>
+            <p><strong>Product:</strong> {log.product}</p>
+            <p><strong>Template:</strong> {log.template}</p>
+            <p><strong>When:</strong> {new Date(log.sentAt).toLocaleString()}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/app/api/admin/email-logs/route.ts
+++ b/app/api/admin/email-logs/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const secret = searchParams.get("secret")
+
+  if (secret !== process.env.NEXT_PUBLIC_ADMIN_SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const logs = await prisma.emailLog.findMany({
+    orderBy: { sentAt: "desc" },
+  })
+
+  return NextResponse.json({ logs })
+}

--- a/app/api/free-download/route.tsx
+++ b/app/api/free-download/route.tsx
@@ -1,6 +1,6 @@
 //app/api/free-download/route.ts
 import { NextResponse } from "next/server"
-import { sendDownloadEmail } from "@/lib/email"
+import { sendEmailByType } from "@/lib/email"
 import { products } from "@/lib/products"
 
 export async function POST(req: Request) {
@@ -12,7 +12,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ success: false, error: "Invalid request" }, { status: 400 })
     }
 
-    await sendDownloadEmail(email, product.title, slug, phone)
+    await sendEmailByType({ email, productSlug: slug })
 
     return NextResponse.json({ success: true })
   } catch (err) {

--- a/lib/purchase.ts
+++ b/lib/purchase.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { sendDownloadEmail } from "@/lib/email";
+import { sendEmailByType } from "@/lib/email";
 
 export async function logPurchase(email: string, slug: string, opts?: { name?: string; phone?: string }) {
   await prisma.purchase.create({
@@ -12,5 +12,5 @@ export async function logPurchase(email: string, slug: string, opts?: { name?: s
     },
   });
 
-  await sendDownloadEmail(email, slug, slug, opts?.phone);
+  await sendEmailByType({ email, productSlug: slug });
 }


### PR DESCRIPTION
## Summary
- implement `sendEmailByType` with product-based templates
- log all sent emails using `EmailLog`
- update purchase and freebie flows to use new handler
- expose email logs API and admin UI to view sends

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a4e16e2a08330a00ba23df46062e1