### PR TITLE
Implement sendEmail status return

### DIFF
--- a/app/api/free-download/route.tsx
+++ b/app/api/free-download/route.tsx
@@ -12,7 +12,11 @@ export async function POST(req: Request) {
       return NextResponse.json({ success: false, error: "Invalid request" }, { status: 400 })
     }
 
-    await sendEmailByType({ email, productSlug: slug })
+    const result = await sendEmailByType({ email, productSlug: slug })
+
+    if (!result.success) {
+      return NextResponse.json({ success: false, error: result.error || 'Email failed' }, { status: 500 })
+    }
 
     return NextResponse.json({ success: true })
   } catch (err) {


### PR DESCRIPTION
## Summary
- extend dynamic email engine with Resend fallback
- return success/error from sendEmailByType
- surface email send errors in free download API

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685a50982e7c8330b3c402211589080f