### PR TITLE
Add email debug logging and dummy purchase email modal

### DIFF
--- a/app/api/checkout/route.tsx
+++ b/app/api/checkout/route.tsx
@@ -6,7 +6,7 @@ import { logPurchase } from "@/lib/purchase"
 // In dummy payment mode we skip Stripe entirely. This API simply logs a
 // purchase and returns the thank-you URL to redirect the user.
 export async function POST(req: Request) {
-  const { slug } = await req.json()
+  const { slug, email } = await req.json()
 
   const product = products[slug]
   if (!product) {
@@ -14,9 +14,9 @@ export async function POST(req: Request) {
   }
 
   try {
-    const email = process.env.TEST_EMAIL || "test@example.com"
-    await logPurchase(email, slug)
-    return NextResponse.json({ url: `/thank-you/${slug}` })
+    const userEmail = email || process.env.TEST_EMAIL || "test@example.com"
+    await logPurchase(userEmail, slug)
+    return NextResponse.json({ success: true })
   } catch (err) {
     console.error("Dummy checkout error", err)
     return NextResponse.json(

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -95,6 +95,10 @@ export async function sendCustomEmail(to: string, subject: string, html: string)
     return
   }
 
+  if (!process.env.RESEND_API_KEY && !(process.env.EMAIL_USER && process.env.EMAIL_PASS)) {
+    console.error('[EMAIL DEBUG] Missing RESEND_API_KEY or SMTP credentials')
+  }
+
   if (!process.env.EMAIL_USER) {
     throw new Error("Missing required environment variables.")
   }
@@ -120,6 +124,10 @@ export async function sendEmailByType({
   email: string
   productSlug: string
 }): Promise<{ success: boolean; error?: string }> {
+  if (!process.env.RESEND_API_KEY && !(process.env.EMAIL_USER && process.env.EMAIL_PASS)) {
+    console.error('[EMAIL DEBUG] Missing RESEND_API_KEY or SMTP credentials')
+  }
+
   const type = getEmailType(productSlug)
   const product = products[productSlug]
   if (!product) {


### PR DESCRIPTION
## Summary
- improve Resend/Nodemailer debugging output
- extend dummy checkout API to accept email and return `{ success: true }`
- prompt for email before dummy purchase
- show toast and on-page confirmation when email is sent

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685a54034f008330b4a00e58db38d439