### PR TITLE
Fix email test flow and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Example environment file
+# Rename to .env.local and fill your values
+
+# Public site URL used in emails
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
+# Admin dashboard secret token
+NEXT_PUBLIC_ADMIN_SECRET=dev-secret-123
+
+# Payment configuration
+STRIPE_SECRET_KEY=
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
+DUMMY_PAYMENT_MODE=true
+
+# Email provider
+RESEND_API_KEY=
+TEST_EMAIL=
+
+# Optional: OpenAI key for AI features
+OPENAI_API_KEY=
+
+# Database connection
+DATABASE_URL=

--- a/ADMIN_SECRET.md
+++ b/ADMIN_SECRET.md
@@ -1,0 +1,9 @@
+# Admin Access Token
+
+Use the token below as the value for `NEXT_PUBLIC_ADMIN_SECRET` in your `.env.local` file.
+
+```
+dev-secret-123
+```
+
+Enter this same token when prompted on the admin pages (`/admin` or `/admin/emails`).

--- a/app/api/free-download/route.tsx
+++ b/app/api/free-download/route.tsx
@@ -18,7 +18,9 @@ export async function POST(req: Request) {
       return NextResponse.json({ success: false, error: result.error || 'Email failed' }, { status: 500 })
     }
 
-    return NextResponse.json({ success: true })
+    const downloadUrl = `${process.env.NEXT_PUBLIC_SITE_URL}/downloads/${slug}.pdf`
+
+    return NextResponse.json({ success: true, downloadUrl })
   } catch (err) {
     console.error("🔥 API /free-download error:", err)
     return NextResponse.json({ success: false, error: "Server error" }, { status: 500 })

--- a/components/sections/freebie.tsx
+++ b/components/sections/freebie.tsx
@@ -8,6 +8,7 @@ export default function FreebieSection() {
   const [phone, setPhone] = useState('')
   const [loading, setLoading] = useState(false)
   const [sent, setSent] = useState(false)
+  const [link, setLink] = useState('')
 
   if (!freeProduct) return null
 
@@ -20,7 +21,9 @@ export default function FreebieSection() {
       body: JSON.stringify({ slug: freeProduct.slug, email, phone })
     })
     if (res.ok) {
+      const data = await res.json()
       setSent(true)
+      if (data.downloadUrl) setLink(data.downloadUrl)
       setEmail('')
       setPhone('')
     }
@@ -58,7 +61,13 @@ export default function FreebieSection() {
             {loading ? 'Sending...' : freeProduct.ctaLabel}
           </button>
           {sent && (
-            <p className="text-green-400 text-sm mt-2">Check your inbox for the download!</p>
+            <p className="text-green-400 text-sm mt-2">
+              Your download is ready{' '}
+              <a href={link} className="underline" download>
+                click here
+              </a>{' '}
+              and check your inbox for a copy.
+            </p>
           )}
         </form>
       </div>

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -132,6 +132,16 @@ export async function sendEmailByType({
     return { success: true }
   }
 
+  // Check if this user already received this template type before.
+  const existingType = await prisma.emailLog.findFirst({
+    where: { email, template: type },
+  })
+  if (existingType) {
+    console.log('Existing type email for', email, type)
+    // Uncomment the next line to prevent re-sending the same template type.
+    // return { success: true }
+  }
+
   const tpl = buildTemplate(type, productSlug)
 
   console.log('[EMAIL DEBUG] RESEND key prefix:', process.env.RESEND_API_KEY?.slice(0, 4))


### PR DESCRIPTION
## Summary
- expose admin token in `ADMIN_SECRET.md`
- add `.env.example` with required environment vars
- show direct download link when requesting a freebie
- log prior sends per template type in `sendEmailByType`
- return download URL from free download API

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a718bda3883308a0175e787f3f133