### PR TITLE
Add admin emails dashboard

### DIFF
--- a/app/admin/emails/RetryButton.tsx
+++ b/app/admin/emails/RetryButton.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function RetryButton({ id }: { id: string }) {
+  const [loading, setLoading] = useState(false)
+
+  const handleRetry = async () => {
+    setLoading(true)
+    await fetch(`/api/admin/retry-email?secret=${process.env.NEXT_PUBLIC_ADMIN_SECRET}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id }),
+    })
+    location.reload()
+  }
+
+  return (
+    <button
+      onClick={handleRetry}
+      disabled={loading}
+      className="text-yellow-300 disabled:opacity-50"
+    >
+      {loading ? 'Retrying...' : 'Retry'}
+    </button>
+  )
+}


### PR DESCRIPTION
## Summary
- add RetryButton component for queue actions
- implement server-side email dashboard using Prisma

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a85891dec83309786d38be7614c87