### PR TITLE
Add admin send panel and bulk email retry

### DIFF
--- a/app/admin/emails/RetryAllButton.tsx
+++ b/app/admin/emails/RetryAllButton.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useState } from 'react'
+import toast from 'react-hot-toast'
+
+export default function RetryAllButton({ product, status, email }: { product?: string; status?: string; email?: string }) {
+  const [loading, setLoading] = useState(false)
+
+  const handle = async () => {
+    setLoading(true)
+    const res = await fetch(`/api/admin/retry-all?secret=${process.env.NEXT_PUBLIC_ADMIN_SECRET}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ product, status, email }),
+    })
+    const data = await res.json()
+    if (data.success) {
+      toast.success(`Retried ${data.count} email(s)`)
+      location.reload()
+    } else {
+      toast.error(data.error || 'Retry failed')
+    }
+    setLoading(false)
+  }
+
+  return (
+    <button onClick={handle} disabled={loading} className="text-yellow-300 disabled:opacity-50">
+      {loading ? 'Retrying...' : 'Retry All'}
+    </button>
+  )
+}

--- a/app/admin/emails/SendEmailPanel.tsx
+++ b/app/admin/emails/SendEmailPanel.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useState } from 'react'
+import toast from 'react-hot-toast'
+
+export default function SendEmailPanel() {
+  const [emails, setEmails] = useState('')
+  const [subject, setSubject] = useState('')
+  const [body, setBody] = useState('')
+  const [mode, setMode] = useState<'to' | 'bcc'>('to')
+  const testEmail = process.env.NEXT_PUBLIC_TEST_EMAIL || ''
+
+  const send = async (test: boolean) => {
+    const list = test ? [testEmail] : emails.split(/[,\n]/).map(e => e.trim()).filter(Boolean)
+    if (!list.length) { toast.error('No emails'); return }
+    const res = await fetch(`/api/admin/manual-email?secret=${process.env.NEXT_PUBLIC_ADMIN_SECRET}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ emails: list, subject, html: body, mode })
+    })
+    const data = await res.json()
+    if (data.success) {
+      toast.success(`Sent to ${data.sentCount} recipient(s)`)
+      if (!test) setEmails('')
+    } else {
+      toast.error(data.error || 'Send failed')
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <textarea
+        className="w-full bg-black text-white border border-gray-500 rounded p-2"
+        rows={3}
+        placeholder="Emails separated by commas or new lines"
+        value={emails}
+        onChange={e => setEmails(e.target.value)}
+      />
+      <input
+        className="w-full bg-black text-white border border-gray-500 rounded p-2"
+        placeholder="Subject"
+        value={subject}
+        onChange={e => setSubject(e.target.value)}
+      />
+      <textarea
+        className="w-full bg-black text-white border border-gray-500 rounded p-2"
+        rows={4}
+        placeholder="HTML Body"
+        value={body}
+        onChange={e => setBody(e.target.value)}
+      />
+      <div className="flex items-center gap-2">
+        <select
+          value={mode}
+          onChange={e => setMode(e.target.value as 'to' | 'bcc')}
+          className="bg-black text-white border border-gray-500 rounded px-3 py-1"
+        >
+          <option value="to">To</option>
+          <option value="bcc">BCC</option>
+        </select>
+        <button
+          onClick={() => send(false)}
+          className="bg-yellow-500 text-black font-semibold px-3 py-1 rounded"
+        >
+          Send
+        </button>
+        {testEmail && (
+          <button
+            onClick={() => send(true)}
+            className="bg-blue-500 text-white font-semibold px-3 py-1 rounded"
+          >
+            Test to {testEmail}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/admin/emails/page.tsx
+++ b/app/admin/emails/page.tsx
@@ -1,16 +1,21 @@
 import { prisma } from '@/lib/prisma'
 import { products } from '@/lib/products'
+import Link from 'next/link'
 import RetryButton from './RetryButton'
+import RetryAllButton from './RetryAllButton'
+import SendEmailPanel from './SendEmailPanel'
 
 interface SearchParams {
+  tab?: string
   product?: string
   status?: string
+  email?: string
 }
 
 export const dynamic = 'force-dynamic'
 
 export default async function EmailActivityPage({ searchParams }: { searchParams: SearchParams }) {
-  const { product, status } = searchParams
+  const { tab = 'sent', product, status, email } = searchParams
 
   const logs = await prisma.emailLog.findMany({
     where: product ? { product } : undefined,
@@ -21,91 +26,115 @@ export default async function EmailActivityPage({ searchParams }: { searchParams
     where: {
       ...(product ? { product } : {}),
       ...(status ? { status } : {}),
+      ...(email ? { email: { contains: email } } : {}),
     },
     orderBy: { retryAt: 'desc' },
   })
 
   return (
     <div className="p-6 text-white">
-      <h1 className="text-2xl font-bold mb-4">📧 Email Activity</h1>
-      <form className="flex flex-wrap gap-2 mb-6">
-        <select
-          name="product"
-          defaultValue={product || ''}
-          className="bg-black text-white border border-gray-500 rounded px-3 py-1"
-        >
-          <option value="">All Products</option>
-          {Object.values(products).map((p) => (
-            <option key={p.slug} value={p.slug}>
-              {p.title}
-            </option>
-          ))}
-        </select>
-        <select
-          name="status"
-          defaultValue={status || ''}
-          className="bg-black text-white border border-gray-500 rounded px-3 py-1"
-        >
-          <option value="">All Statuses</option>
-          <option value="queued">Queued</option>
-          <option value="failed">Failed</option>
-          <option value="delivered">Delivered</option>
-        </select>
-        <button
-          type="submit"
-          className="bg-yellow-500 text-black font-semibold px-4 py-1 rounded"
-        >
-          Apply
-        </button>
-      </form>
-      <div className="overflow-x-auto mb-8">
-        <h2 className="text-xl font-bold mb-2">Sent Emails</h2>
-        <table className="min-w-full bg-[#1f1f2e] rounded-md">
-          <thead>
-            <tr className="text-left bg-[#29293d]">
-              <th className="p-2">Email</th>
-              <th className="p-2">Product</th>
-              <th className="p-2">Sent At</th>
-            </tr>
-          </thead>
-          <tbody>
-            {logs.map((log) => (
-              <tr key={log.id} className="border-t border-[#29293d]">
-                <td className="p-2">{log.email}</td>
-                <td className="p-2">{log.product}</td>
-                <td className="p-2">{log.sentAt.toLocaleString()}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      <h1 className="text-2xl font-bold mb-4">📧 Email Dashboard</h1>
+      <div className="flex gap-6 mb-6">
+        <Link href="/admin/emails?tab=send" className={tab === 'send' ? 'text-yellow-400 font-bold' : ''}>Send</Link>
+        <Link href="/admin/emails?tab=sent" className={tab === 'sent' ? 'text-yellow-400 font-bold' : ''}>Sent</Link>
+        <Link href="/admin/emails?tab=queued" className={tab === 'queued' ? 'text-yellow-400 font-bold' : ''}>Queued</Link>
       </div>
-      <div className="overflow-x-auto">
-        <h2 className="text-xl font-bold mb-2">Queued Emails</h2>
-        <table className="min-w-full bg-[#1f1f2e] rounded-md">
-          <thead>
-            <tr className="text-left bg-[#29293d]">
-              <th className="p-2">Email</th>
-              <th className="p-2">Product</th>
-              <th className="p-2">Retry At</th>
-              <th className="p-2">Status</th>
-              <th className="p-2">Action</th>
-            </tr>
-          </thead>
-          <tbody>
-            {queue.map((q) => (
-              <tr key={q.id} className="border-t border-[#29293d]">
-                <td className="p-2">{q.email}</td>
-                <td className="p-2">{q.product}</td>
-                <td className="p-2">{q.retryAt.toLocaleString()}</td>
-                <td className="p-2 capitalize">{q.status}</td>
-                <td className="p-2">
-                  <RetryButton id={q.id} />
-                </td>
+
+      {tab === 'send' && <SendEmailPanel />}
+
+      {tab === 'sent' && (
+        <div className="overflow-x-auto">
+          <h2 className="text-xl font-bold mb-2">Sent Emails</h2>
+          <table className="min-w-full bg-[#1f1f2e] rounded-md">
+            <thead>
+              <tr className="text-left bg-[#29293d]">
+                <th className="p-2">Email</th>
+                <th className="p-2">Product</th>
+                <th className="p-2">Sent At</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+            </thead>
+            <tbody>
+              {logs.map((log) => (
+                <tr key={log.id} className="border-t border-[#29293d]">
+                  <td className="p-2">{log.email}</td>
+                  <td className="p-2">{log.product}</td>
+                  <td className="p-2">{log.sentAt.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {tab === 'queued' && (
+        <div className="overflow-x-auto">
+          <form className="flex flex-wrap gap-2 mb-4">
+            <input type="hidden" name="tab" value="queued" />
+            <select
+              name="product"
+              defaultValue={product || ''}
+              className="bg-black text-white border border-gray-500 rounded px-3 py-1"
+            >
+              <option value="">All Products</option>
+              {Object.values(products).map((p) => (
+                <option key={p.slug} value={p.slug}>
+                  {p.title}
+                </option>
+              ))}
+            </select>
+            <select
+              name="status"
+              defaultValue={status || ''}
+              className="bg-black text-white border border-gray-500 rounded px-3 py-1"
+            >
+              <option value="">All Statuses</option>
+              <option value="queued">Queued</option>
+              <option value="failed">Failed</option>
+              <option value="delivered">Delivered</option>
+            </select>
+            <input
+              type="text"
+              name="email"
+              defaultValue={email || ''}
+              placeholder="Filter email"
+              className="bg-black text-white border border-gray-500 rounded px-3 py-1"
+            />
+            <button
+              type="submit"
+              className="bg-yellow-500 text-black font-semibold px-4 py-1 rounded"
+            >
+              Apply
+            </button>
+          </form>
+          <div className="mb-2">
+            <RetryAllButton product={product} status={status} email={email} />
+          </div>
+          <table className="min-w-full bg-[#1f1f2e] rounded-md">
+            <thead>
+              <tr className="text-left bg-[#29293d]">
+                <th className="p-2">Email</th>
+                <th className="p-2">Product</th>
+                <th className="p-2">Retry At</th>
+                <th className="p-2">Status</th>
+                <th className="p-2">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {queue.map((q) => (
+                <tr key={q.id} className="border-t border-[#29293d]">
+                  <td className="p-2">{q.email}</td>
+                  <td className="p-2">{q.product}</td>
+                  <td className="p-2">{q.retryAt.toLocaleString()}</td>
+                  <td className="p-2 capitalize">{q.status}</td>
+                  <td className="p-2">
+                    <RetryButton id={q.id} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   )
 }

--- a/app/api/admin/manual-email/route.ts
+++ b/app/api/admin/manual-email/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { Resend } from "resend";
+
+export async function POST(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const secret = searchParams.get("secret");
+  if (secret !== process.env.NEXT_PUBLIC_ADMIN_SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { emails, subject, html, mode } = await req.json();
+  if (!emails || !Array.isArray(emails) || !subject || !html) {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+  }
+
+  const unique = Array.from(new Set(emails.map((e: string) => e.trim()).filter(Boolean)));
+  const allowed: string[] = [];
+  for (const email of unique) {
+    const log = await prisma.emailLog.findUnique({
+      where: { email_template: { email, template: "custom" } },
+    });
+    if (log && log.count >= 3) continue;
+    allowed.push(email);
+    if (log) {
+      await prisma.emailLog.update({
+        where: { email_template: { email, template: "custom" } },
+        data: { count: { increment: 1 }, sentAt: new Date() },
+      });
+    } else {
+      await prisma.emailLog.create({
+        data: { email, product: "manual", template: "custom" },
+      });
+    }
+  }
+
+  if (!allowed.length) {
+    return NextResponse.json({ error: "No eligible recipients" }, { status: 400 });
+  }
+
+  const resend = new Resend(process.env.RESEND_API_KEY || "");
+  const from = process.env.EMAIL_FROM || "info@ubc-finance.com";
+  if (mode === "bcc") {
+    await resend.emails.send({ from, to: from, bcc: allowed, subject, html });
+  } else {
+    for (const email of allowed) {
+      await resend.emails.send({ from, to: email, subject, html });
+    }
+  }
+
+  return NextResponse.json({ success: true, sentCount: allowed.length });
+}

--- a/app/api/admin/retry-all/route.ts
+++ b/app/api/admin/retry-all/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { sendEmailByType } from "@/lib/email";
+
+export async function POST(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const secret = searchParams.get("secret");
+  if (secret !== process.env.NEXT_PUBLIC_ADMIN_SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { product, status, email } = await req.json();
+
+  const queue = await prisma.emailQueue.findMany({
+    where: {
+      ...(product ? { product } : {}),
+      ...(status ? { status } : {}),
+      ...(email ? { email } : {}),
+    },
+  });
+
+  let count = 0;
+  for (const entry of queue) {
+    const result = await sendEmailByType({ email: entry.email, productSlug: entry.product });
+    if (result.success) {
+      await prisma.emailQueue.update({ where: { id: entry.id }, data: { status: "delivered" } });
+      count++;
+    } else {
+      await prisma.emailQueue.update({
+        where: { id: entry.id },
+        data: { reason: result.error || "failed", retryAt: new Date(Date.now() + 24 * 60 * 60 * 1000) },
+      });
+    }
+  }
+
+  return NextResponse.json({ success: true, count });
+}


### PR DESCRIPTION
## Summary
- allow admins to send custom emails through new `SendEmailPanel`
- add API route for manual emails with resend + EmailLog tracking
- add bulk retry API and `RetryAllButton`
- redesign admin email page with tabs and queue filters

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a8f67c48c833094e832fcbaa09098