### PR TITLE
Enhance email engine and secure admin area

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ DUMMY_PAYMENT_MODE=true
 
 # Email provider
 RESEND_API_KEY=
+EMAIL_FROM=
 TEST_EMAIL=
 
 # Optional: OpenAI key for AI features

--- a/app/admin/emails/page.tsx
+++ b/app/admin/emails/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import RetryButton from './RetryButton'
 import RetryAllButton from './RetryAllButton'
 import SendEmailPanel from './SendEmailPanel'
+import { cookies } from 'next/headers'
 
 interface SearchParams {
   tab?: string
@@ -15,6 +16,11 @@ interface SearchParams {
 export const dynamic = 'force-dynamic'
 
 export default async function EmailActivityPage({ searchParams }: { searchParams: SearchParams }) {
+  const cookie = cookies().get('admin_secret')?.value
+  if (cookie !== process.env.NEXT_PUBLIC_ADMIN_SECRET) {
+    return <div className="p-6 text-white">Unauthorized</div>
+  }
+
   const { tab = 'sent', product, status, email } = searchParams
 
   const logs = await prisma.emailLog.findMany({

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -12,8 +12,14 @@ export default function AdminDashboard() {
   const [status, setStatus] = useState("")
 
   useEffect(() => {
+    const existing = document.cookie.split('; ').find(c => c.startsWith('admin_secret='))?.split('=')[1]
+    if (existing === process.env.NEXT_PUBLIC_ADMIN_SECRET) {
+      setAuth(true)
+      return
+    }
     const key = prompt("Enter admin secret:")
     if (key === process.env.NEXT_PUBLIC_ADMIN_SECRET) {
+      document.cookie = `admin_secret=${key}; path=/; max-age=${60 * 60 * 24 * 30}`
       setAuth(true)
     } else {
       alert("Unauthorized")

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(req: NextRequest) {
+  if (req.nextUrl.pathname.startsWith('/admin')) {
+    const token = req.cookies.get('admin_secret')?.value
+    if (token !== process.env.NEXT_PUBLIC_ADMIN_SECRET) {
+      return new NextResponse('Unauthorized', { status: 401 })
+    }
+  }
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/admin/:path*'],
+}


### PR DESCRIPTION
## Summary
- update email templates to use `/thank-you/[slug]` and footer
- prevent duplicate emails by checking log
- log custom emails with Prisma
- set admin auth cookie and protect `/admin` with middleware
- add `EMAIL_FROM` to `.env.example`

## Testing
- `npm install` *(fails: RequestError 403)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa67fdc6c8330a8f5e5b7101ab8c7