### PR TITLE
Implement admin email override & UI improvements

### DIFF
--- a/app/admin/emails/RetryAllButton.tsx
+++ b/app/admin/emails/RetryAllButton.tsx
@@ -5,13 +5,14 @@ import toast from 'react-hot-toast'
 
 export default function RetryAllButton({ product, status, email }: { product?: string; status?: string; email?: string }) {
   const [loading, setLoading] = useState(false)
+  const [force, setForce] = useState(false)
 
   const handle = async () => {
     setLoading(true)
     const res = await fetch(`/api/admin/retry-all?secret=${process.env.NEXT_PUBLIC_ADMIN_SECRET}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ product, status, email }),
+      body: JSON.stringify({ product, status, email, forceSend: force }),
     })
     const data = await res.json()
     if (data.success) {
@@ -24,8 +25,14 @@ export default function RetryAllButton({ product, status, email }: { product?: s
   }
 
   return (
-    <button onClick={handle} disabled={loading} className="text-yellow-300 disabled:opacity-50">
-      {loading ? 'Retrying...' : 'Retry All'}
-    </button>
+    <div className="flex items-center gap-2">
+      <button onClick={handle} disabled={loading} className="text-yellow-300 disabled:opacity-50">
+        {loading ? 'Retrying...' : 'Retry All'}
+      </button>
+      <label className="text-xs flex items-center gap-1">
+        <input type="checkbox" checked={force} onChange={e => setForce(e.target.checked)} />
+        Force
+      </label>
+    </div>
   )
 }

--- a/app/admin/emails/RetryButton.tsx
+++ b/app/admin/emails/RetryButton.tsx
@@ -4,24 +4,31 @@ import { useState } from 'react'
 
 export default function RetryButton({ id }: { id: string }) {
   const [loading, setLoading] = useState(false)
+  const [force, setForce] = useState(false)
 
   const handleRetry = async () => {
     setLoading(true)
     await fetch(`/api/admin/retry-email?secret=${process.env.NEXT_PUBLIC_ADMIN_SECRET}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id }),
+      body: JSON.stringify({ id, forceSend: force }),
     })
     location.reload()
   }
 
   return (
-    <button
-      onClick={handleRetry}
-      disabled={loading}
-      className="text-yellow-300 disabled:opacity-50"
-    >
-      {loading ? 'Retrying...' : 'Retry'}
-    </button>
+    <div className="flex items-center gap-2">
+      <button
+        onClick={handleRetry}
+        disabled={loading}
+        className="text-yellow-300 disabled:opacity-50"
+      >
+        {loading ? 'Retrying...' : 'Retry'}
+      </button>
+      <label className="text-xs flex items-center gap-1">
+        <input type="checkbox" checked={force} onChange={e => setForce(e.target.checked)} />
+        Force
+      </label>
+    </div>
   )
 }

--- a/app/api/admin/retry-all/route.ts
+++ b/app/api/admin/retry-all/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: Request) {
   if (secret !== process.env.NEXT_PUBLIC_ADMIN_SECRET) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
-  const { product, status, email } = await req.json();
+  const { product, status, email, forceSend } = await req.json();
 
   const queue = await prisma.emailQueue.findMany({
     where: {
@@ -20,7 +20,7 @@ export async function POST(req: Request) {
 
   let count = 0;
   for (const entry of queue) {
-    const result = await sendEmailByType({ email: entry.email, productSlug: entry.product });
+    const result = await sendEmailByType({ email: entry.email, productSlug: entry.product, forceSend });
     if (result.success) {
       await prisma.emailQueue.update({ where: { id: entry.id }, data: { status: "delivered" } });
       count++;

--- a/app/api/admin/retry-email/route.ts
+++ b/app/api/admin/retry-email/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: Request) {
   if (secret !== process.env.NEXT_PUBLIC_ADMIN_SECRET) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
-  const { id } = await req.json();
+  const { id, forceSend } = await req.json();
   if (!id) {
     return NextResponse.json({ error: "Missing id" }, { status: 400 });
   }
@@ -18,7 +18,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 
-  const result = await sendEmailByType({ email: entry.email, productSlug: entry.product });
+  const result = await sendEmailByType({ email: entry.email, productSlug: entry.product, forceSend });
   if (result.success) {
     await prisma.emailQueue.update({ where: { id }, data: { status: 'delivered' } });
     return NextResponse.json({ success: true });


### PR DESCRIPTION
## Summary
- enable dynamic sender address and update email logic
- add `forceSend` option in email API and UI
- show email send counts for queued emails
- fix admin cookie retrieval

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab56a53248330b8b4e1ba45ac8f08