### PR TITLE
Fix admin cookie check

### DIFF
--- a/app/admin/emails/page.tsx
+++ b/app/admin/emails/page.tsx
@@ -16,12 +16,13 @@ interface SearchParams {
 export const dynamic = 'force-dynamic'
 
 export default async function EmailActivityPage({ searchParams }: { searchParams: SearchParams }) {
-  const cookie = await cookies().get('admin_secret')?.value
+  const cookieStore = await cookies()
+  const cookie = cookieStore.get('admin_secret')?.value
   if (cookie !== process.env.NEXT_PUBLIC_ADMIN_SECRET) {
     return <div className="p-6 text-white">Unauthorized</div>
   }
 
-  const { tab = 'sent', product, status, email } = searchParams
+  const { tab = 'sent', product, status, email } = await searchParams
 
   const logs = await prisma.emailLog.findMany({
     where: product ? { product } : undefined,


### PR DESCRIPTION
## Summary
- fix cookie retrieval for admin page
- await search params before destructuring

## Testing
- `pnpm lint` *(fails: requires eslint setup)*
- `pnpm build` *(fails: could not fetch fonts from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_685abd7ca97483308ac3339c044698e5