### PR TITLE
Secure admin secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,8 @@
 # Public site URL used in emails
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
-# Admin dashboard secret token
-NEXT_PUBLIC_ADMIN_SECRET=dev-secret-123
+# Admin dashboard secret token (do not expose publicly)
+ADMIN_SECRET=dev-secret-123
 
 # Payment configuration
 STRIPE_SECRET_KEY=

--- a/ADMIN_SECRET.md
+++ b/ADMIN_SECRET.md
@@ -1,6 +1,6 @@
 # Admin Access Token
 
-Use the token below as the value for `NEXT_PUBLIC_ADMIN_SECRET` in your `.env.local` file.
+Use the token below as the value for `ADMIN_SECRET` in your `.env.local` file.
 
 ```
 dev-secret-123

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## 🛠 Quick Build Steps
 1. Clone this repo
 2. Run `npm install`
-3. Copy `.env.local.example` to `.env.local` and fill in values.
+3. Copy `.env.local.example` to `.env.local` and fill in values (including `ADMIN_SECRET`).
 4. Run `npm run dev`
 5. Deploy with Vercel
 

--- a/app/admin/emails/RetryAllButton.tsx
+++ b/app/admin/emails/RetryAllButton.tsx
@@ -9,7 +9,7 @@ export default function RetryAllButton({ product, status, email }: { product?: s
 
   const handle = async () => {
     setLoading(true)
-    const res = await fetch(`/api/admin/retry-all?secret=${process.env.NEXT_PUBLIC_ADMIN_SECRET}`, {
+    const res = await fetch(`/api/admin/retry-all`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ product, status, email, forceSend: force }),

--- a/app/admin/emails/RetryButton.tsx
+++ b/app/admin/emails/RetryButton.tsx
@@ -8,7 +8,7 @@ export default function RetryButton({ id }: { id: string }) {
 
   const handleRetry = async () => {
     setLoading(true)
-    await fetch(`/api/admin/retry-email?secret=${process.env.NEXT_PUBLIC_ADMIN_SECRET}`, {
+    await fetch(`/api/admin/retry-email`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id, forceSend: force }),

--- a/app/admin/emails/SendEmailPanel.tsx
+++ b/app/admin/emails/SendEmailPanel.tsx
@@ -13,7 +13,7 @@ export default function SendEmailPanel() {
   const send = async (test: boolean) => {
     const list = test ? [testEmail] : emails.split(/[,\n]/).map(e => e.trim()).filter(Boolean)
     if (!list.length) { toast.error('No emails'); return }
-    const res = await fetch(`/api/admin/manual-email?secret=${process.env.NEXT_PUBLIC_ADMIN_SECRET}`, {
+    const res = await fetch(`/api/admin/manual-email`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ emails: list, subject, html: body, mode })

--- a/app/admin/emails/page.tsx
+++ b/app/admin/emails/page.tsx
@@ -18,7 +18,7 @@ export const dynamic = 'force-dynamic'
 export default async function EmailActivityPage({ searchParams }: { searchParams: SearchParams }) {
   const cookieStore = await cookies()
   const cookie = cookieStore.get('admin_secret')?.value
-  if (cookie !== process.env.NEXT_PUBLIC_ADMIN_SECRET) {
+  if (cookie !== process.env.ADMIN_SECRET) {
     return <div className="p-6 text-white">Unauthorized</div>
   }
 

--- a/app/api/admin/check/route.ts
+++ b/app/api/admin/check/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+
+export async function GET() {
+  const secret = cookies().get('admin_secret')?.value
+  if (secret !== process.env.ADMIN_SECRET) {
+    return NextResponse.json({ authorized: false }, { status: 401 })
+  }
+  return NextResponse.json({ authorized: true })
+}

--- a/app/api/admin/email-logs/route.ts
+++ b/app/api/admin/email-logs/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from "next/server"
 import { prisma } from "@/lib/prisma"
+import { cookies } from "next/headers"
 
 export async function GET(req: Request) {
-  const { searchParams } = new URL(req.url)
-  const secret = searchParams.get("secret")
+  const cookieStore = cookies()
+  const secret = cookieStore.get("admin_secret")?.value
 
-  if (secret !== process.env.NEXT_PUBLIC_ADMIN_SECRET) {
+  if (secret !== process.env.ADMIN_SECRET) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
   }
 

--- a/app/api/admin/email-queue/route.ts
+++ b/app/api/admin/email-queue/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { cookies } from "next/headers";
 
 export async function GET(req: Request) {
-  const { searchParams } = new URL(req.url);
-  const secret = searchParams.get("secret");
-  if (secret !== process.env.NEXT_PUBLIC_ADMIN_SECRET) {
+  const cookieStore = cookies();
+  const secret = cookieStore.get("admin_secret")?.value;
+  if (secret !== process.env.ADMIN_SECRET) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/app/api/admin/login/route.ts
+++ b/app/api/admin/login/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+
+export async function POST(req: Request) {
+  const { secret } = await req.json()
+  if (secret !== process.env.ADMIN_SECRET) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const res = NextResponse.json({ success: true })
+  res.cookies.set('admin_secret', secret, { httpOnly: true, path: '/', maxAge: 60 * 60 * 24 * 30 })
+  return res
+}

--- a/app/api/admin/manual-email/route.ts
+++ b/app/api/admin/manual-email/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { Resend } from "resend";
+import { cookies } from "next/headers";
 
 export async function POST(req: Request) {
-  const { searchParams } = new URL(req.url);
-  const secret = searchParams.get("secret");
-  if (secret !== process.env.NEXT_PUBLIC_ADMIN_SECRET) {
+  const cookieStore = cookies();
+  const secret = cookieStore.get("admin_secret")?.value;
+  if (secret !== process.env.ADMIN_SECRET) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/app/api/admin/purchases/route.ts
+++ b/app/api/admin/purchases/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from "next/server"
 import { prisma } from "@/lib/prisma"
+import { cookies } from "next/headers"
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url)
   const slug = searchParams.get("slug")
-  const secret = searchParams.get("secret")
+  const cookieStore = cookies()
+  const secret = cookieStore.get("admin_secret")?.value
 
-  if (secret !== process.env.NEXT_PUBLIC_ADMIN_SECRET) {
+  if (secret !== process.env.ADMIN_SECRET) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
   }
 

--- a/app/api/admin/retry-all/route.ts
+++ b/app/api/admin/retry-all/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { sendEmailByType } from "@/lib/email";
+import { cookies } from "next/headers";
 
 export async function POST(req: Request) {
-  const { searchParams } = new URL(req.url);
-  const secret = searchParams.get("secret");
-  if (secret !== process.env.NEXT_PUBLIC_ADMIN_SECRET) {
+  const cookieStore = cookies();
+  const secret = cookieStore.get("admin_secret")?.value;
+  if (secret !== process.env.ADMIN_SECRET) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   const { product, status, email, forceSend } = await req.json();

--- a/app/api/admin/retry-email/route.ts
+++ b/app/api/admin/retry-email/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { sendEmailByType } from "@/lib/email";
+import { cookies } from "next/headers";
 
 export async function POST(req: Request) {
-  const { searchParams } = new URL(req.url);
-  const secret = searchParams.get("secret");
-  if (secret !== process.env.NEXT_PUBLIC_ADMIN_SECRET) {
+  const cookieStore = cookies();
+  const secret = cookieStore.get("admin_secret")?.value;
+  if (secret !== process.env.ADMIN_SECRET) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   const { id, forceSend } = await req.json();

--- a/app/api/admin/send-email/route.ts
+++ b/app/api/admin/send-email/route.ts
@@ -1,12 +1,13 @@
 import { NextResponse } from "next/server"
 import { prisma } from "@/lib/prisma"
 import { sendCustomEmail } from "@/lib/email"
+import { cookies } from "next/headers"
 
 export async function POST(req: Request) {
-  const { searchParams } = new URL(req.url)
-  const secret = searchParams.get("secret")
+  const cookieStore = cookies()
+  const secret = cookieStore.get("admin_secret")?.value
 
-  if (secret !== process.env.NEXT_PUBLIC_ADMIN_SECRET) {
+  if (secret !== process.env.ADMIN_SECRET) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
   }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,7 +4,7 @@ import type { NextRequest } from 'next/server'
 export function middleware(req: NextRequest) {
   if (req.nextUrl.pathname.startsWith('/admin')) {
     const token = req.cookies.get('admin_secret')?.value
-    if (token !== process.env.NEXT_PUBLIC_ADMIN_SECRET) {
+    if (token !== process.env.ADMIN_SECRET) {
       return new NextResponse('Unauthorized', { status: 401 })
     }
   }


### PR DESCRIPTION
## Summary
- migrate NEXT_PUBLIC_ADMIN_SECRET to private ADMIN_SECRET
- check login via new `/api/admin/check` and `/api/admin/login`
- require ADMIN_SECRET cookie in middleware and admin API routes
- update admin pages and components to use new endpoints
- document ADMIN_SECRET setup

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685abf352f6483309d352d04be98ce0d