### PR TITLE
Add theme and layout switcher

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -10,14 +10,46 @@
 :root {
   --font-sans: 'Inter', sans-serif;
   --font-heading: 'Space Grotesk', sans-serif;
-  padding: 5%
+  --bg-body: #0b0815;
+  --text-body: #ffffff;
+  --bg-header: #1a1a2b;
+  --border: #2a2a3a;
+  --accent: #facc15;
+  --highlight: #facc15;
+  --section-bg: #0f0f1c;
+  --card-bg: #151525;
+  padding: 5%;
 }
 
-/* ✅ Global body defaults */
 body {
-  @apply bg-[#0b0815] text-white font-sans antialiased;
-  /* @apply bg-[#0A0A0A] text-white font-sans antialiased p-[5%]; */
+  @apply font-sans antialiased;
+  background: var(--bg-body);
+  color: var(--text-body);
 }
+
+.bg-header { background: var(--bg-header); }
+.border-border { border-color: var(--border); }
+.border-accent { border-color: var(--accent); }
+.text-accent { color: var(--accent); }
+.bg-highlight { background: var(--highlight); }
+.bg-section { background: var(--section-bg); }
+.bg-card { background: var(--card-bg); }
+
+/* Theme variations */
+.theme-modern { --bg-body:#0b0815; --text-body:#ffffff; --bg-header:#1a1a2b; --border:#2a2a3a; --accent:#facc15; --highlight:#facc15; --section-bg:#0f0f1c; --card-bg:#151525; }
+.theme-elegant { --bg-body:#1a1616; --text-body:#f8f5f2; --bg-header:#302626; --border:#504040; --accent:#e0c58e; --highlight:#e0c58e; --section-bg:#262222; --card-bg:#3a2f2f; }
+.theme-minimal { --bg-body:#ffffff; --text-body:#000000; --bg-header:#f4f4f4; --border:#d4d4d4; --accent:#111111; --highlight:#333333; --section-bg:#ffffff; --card-bg:#f4f4f4; }
+.theme-futuristic { --bg-body:#050811; --text-body:#d0fcff; --bg-header:#06121e; --border:#123040; --accent:#3cfefb; --highlight:#3cfefb; --section-bg:#09172a; --card-bg:#0e223b; }
+.theme-sci-fi { --bg-body:#080a16; --text-body:#e0e0ff; --bg-header:#141630; --border:#2c2e50; --accent:#a484ff; --highlight:#a484ff; --section-bg:#10142a; --card-bg:#1a2042; }
+
+/* Layout variations */
+.layout-default {}
+.layout-wide {}
+
+@keyframes fade { from { opacity:0 } to { opacity:1 } }
+.animate-fade { animation: fade 0.3s ease-in-out; }
+@keyframes slide { from { transform: translateY(10px); opacity:0 } to { transform:none; opacity:1 } }
+.animate-slide { animation: slide 0.3s ease-in-out; }
 
 .scroll-shadow {
   overflow-y: auto;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+"use client"
 // app/layout.tsx
 import "./globals.css"
 import { Inter, Space_Grotesk } from "next/font/google"
@@ -21,6 +22,35 @@ export const metadata: Metadata = {
   description: "A premium digital shop offering AI-powered marketing tips, branding guides, and expert ebooks.",
 }
 
+import { ThemeProvider, useTheme } from "@/components/context/theme-context"
+
+function BodyWrapper({ children }: { children: React.ReactNode }) {
+  const { theme, layout, animation } = useTheme()
+  return (
+    <body
+      className={`
+        ${inter.variable} ${spaceGrotesk.variable}
+        font-sans text-white theme-${theme} layout-${layout}
+      `}
+    >
+      <div className={`relative group ${layout === "wide" ? "" : "max-w-6xl mx-auto"}`}>        
+        <Header />
+        <Toaster position="top-center" />
+        {process.env.DUMMY_PAYMENT_MODE === "true" && (
+          <div className="bg-red-600 text-center text-sm py-2">
+            Payments are simulated for testing. No real transaction is made.
+          </div>
+        )}
+
+        {/* App content */}
+        <main className={animation === "fade" ? "animate-fade" : "animate-slide"}>
+          {children}
+        </main>
+      </div>
+    </body>
+  )
+}
+
 export default function RootLayout({
   children,
 }: {
@@ -28,28 +58,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className="dark">
-      <body
-        className={`
-          ${inter.variable} ${spaceGrotesk.variable}
-          font-sans bg-background text-white
-        `}
-      >
-        {/* Fancy glow container */}
-        <div className="relative group max-w-6xl mx-auto">
-            <Header />
-            <Toaster position="top-center" />
-            {process.env.DUMMY_PAYMENT_MODE === "true" && (
-              <div className="bg-red-600 text-center text-sm py-2">
-                Payments are simulated for testing. No real transaction is made.
-              </div>
-            )}
-            
-            {/* App content */}
-            <main>
-              {children}
-            </main>
-          </div>
-      </body>
+      <ThemeProvider>
+        <BodyWrapper>{children}</BodyWrapper>
+      </ThemeProvider>
     </html>
   )
 }

--- a/components/context/theme-context.tsx
+++ b/components/context/theme-context.tsx
@@ -1,0 +1,35 @@
+"use client"
+import { createContext, useContext, useState, ReactNode } from "react"
+
+export type Theme = "modern" | "elegant" | "minimal" | "futuristic" | "sci-fi"
+export type Layout = "default" | "wide"
+export type Animation = "fade" | "slide"
+
+interface ThemeContextValue {
+  theme: Theme
+  setTheme: (t: Theme) => void
+  layout: Layout
+  setLayout: (l: Layout) => void
+  animation: Animation
+  setAnimation: (a: Animation) => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error("ThemeContext not found")
+  return ctx
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>("modern")
+  const [layout, setLayout] = useState<Layout>("default")
+  const [animation, setAnimation] = useState<Animation>("fade")
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, layout, setLayout, animation, setAnimation }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -1,7 +1,7 @@
 // components/layout/footer.tsx
 export default function Footer() {
   return (
-    <footer className="bg-[#0f0f1c] text-center text-sm text-gray-500 py-6">
+    <footer className="bg-section text-center text-sm text-gray-500 py-6">
       &copy; 2025 June. All rights reserved.
     </footer>
   )

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,20 +1,38 @@
+"use client"
 // components/layout/header.tsx
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
+import { useTheme } from "@/components/context/theme-context"
 
 export default function Header() {
+  const { theme, setTheme, layout, setLayout, animation, setAnimation } = useTheme()
   return (
-<header className="bg-[#1a1a2b] border-t border-[#2a2a3a] shadow-md rounded-t-2xl max-w-6xl mx-auto px-8 py-6 flex justify-between items-center">
-  <nav className="flex gap-6 text-sm font-semibold text-gray-300">
-    <Link href="/" className="text-white hover:text-yellow-400 transition">Home</Link>
-    <Link href="/blog" className="text-white hover:text-yellow-400 transition">Blog</Link>
-    <Link href="/about" className="text-white hover:text-yellow-400 transition">About</Link>
-  </nav>
-  <Button className="bg-gradient-to-r from-purple-600 to-purple-500 hover:from-purple-500 hover:to-purple-400 text-white font-bold shadow-md">
-    Buy Now
-  </Button>
-</header>
-
-
+    <header className="bg-header border-t border-border shadow-md rounded-t-2xl px-8 py-6 flex flex-wrap gap-4 justify-between items-center">
+      <nav className="flex gap-6 text-sm font-semibold text-gray-300">
+        <Link href="/" className="text-white hover:text-accent transition">Home</Link>
+        <Link href="/blog" className="text-white hover:text-accent transition">Blog</Link>
+        <Link href="/about" className="text-white hover:text-accent transition">About</Link>
+      </nav>
+      <div className="flex items-center gap-4 flex-wrap">
+        <select value={theme} onChange={e => setTheme(e.target.value as any)} className="bg-header border border-border rounded px-2 py-1 text-sm">
+          <option value="modern">Modern</option>
+          <option value="elegant">Elegant</option>
+          <option value="minimal">Minimal</option>
+          <option value="futuristic">Futuristic</option>
+          <option value="sci-fi">Sci-Fi</option>
+        </select>
+        <select value={layout} onChange={e => setLayout(e.target.value as any)} className="bg-header border border-border rounded px-2 py-1 text-sm">
+          <option value="default">Default Layout</option>
+          <option value="wide">Wide Layout</option>
+        </select>
+        <select value={animation} onChange={e => setAnimation(e.target.value as any)} className="bg-header border border-border rounded px-2 py-1 text-sm">
+          <option value="fade">Fade</option>
+          <option value="slide">Slide</option>
+        </select>
+        <Button className="bg-gradient-to-r from-purple-600 to-purple-500 hover:from-purple-500 hover:to-purple-400 text-white font-bold shadow-md">
+          Buy Now
+        </Button>
+      </div>
+    </header>
   )
 }

--- a/components/sections/bundle.tsx
+++ b/components/sections/bundle.tsx
@@ -6,17 +6,17 @@ export default function BundleSection() {
   if (!bundle) return null
 
   return (
-    <section className="bg-[#0d1522] px-6 py-20 max-w-6xl mx-auto">
+    <section className="bg-section px-6 py-20">
       <h2 className="text-accent text-sm font-semibold mb-8">🔥 Everything in One Bundle</h2>
       <Link
         href={`/products/${bundle.slug}`}
-        className="block bg-[#151525] border border-[#2c2c40] p-8 rounded-xl shadow-md grid md:grid-cols-2 gap-8 items-center hover:shadow-xl transition-all duration-200"
+        className="block bg-card border border-border p-8 rounded-xl shadow-md grid md:grid-cols-2 gap-8 items-center hover:shadow-xl transition-all duration-200"
       >
         <img src={bundle.image} alt={bundle.title} className="rounded-lg" />
         <div>
           <h3 className="text-2xl font-bold text-white mb-4">{bundle.title}</h3>
           <p className="text-purple-200 text-sm mb-4">{bundle.description}</p>
-          <span className="inline-flex items-center gap-2 text-yellow-300 text-sm font-medium hover:underline">
+          <span className="inline-flex items-center gap-2 text-accent text-sm font-medium hover:underline">
             Explore the Bundle <ArrowRight className="w-4 h-4" />
           </span>
         </div>

--- a/components/sections/course/course-benefits.tsx
+++ b/components/sections/course/course-benefits.tsx
@@ -13,9 +13,9 @@ const benefits = [
 
 export default function CourseBenefits() {
   return (
-    <section className="bg-[#151525] py-16 px-6">
+    <section className="bg-card py-16 px-6">
       <div className="max-w-4xl mx-auto text-center">
-        <h2 className="text-2xl sm:text-3xl font-heading font-bold text-yellow-300 mb-6">
+        <h2 className="text-2xl sm:text-3xl font-heading font-bold text-accent mb-6">
           What’s Included
         </h2>
 

--- a/components/sections/course/course-bonuses.tsx
+++ b/components/sections/course/course-bonuses.tsx
@@ -18,19 +18,19 @@ const bonuses = [
 
 export default function CourseBonuses() {
   return (
-    <section className="bg-[#0f0f1c] px-6 py-20">
+    <section className="bg-section px-6 py-20">
       <div className="max-w-5xl mx-auto text-center">
-        <h2 className="text-2xl sm:text-3xl font-heading font-bold text-yellow-300 mb-10">
+        <h2 className="text-2xl sm:text-3xl font-heading font-bold text-accent mb-10">
           Fast-Action Bonuses
         </h2>
         <div className="grid sm:grid-cols-2 gap-6">
           {bonuses.map((bonus, i) => (
             <div
               key={i}
-              className="bg-[#1f1f2e] border border-[#2e2e40] p-6 rounded-xl text-left shadow-md"
+              className="bg-card border border-border p-6 rounded-xl text-left shadow-md"
             >
               <div className="flex items-start gap-3 mb-2">
-                <Gift className="w-5 h-5 text-yellow-300 mt-1" />
+                <Gift className="w-5 h-5 text-accent mt-1" />
                 <h3 className="text-white font-semibold text-md">{bonus.title}</h3>
               </div>
               <p className="text-purple-300 text-sm">{bonus.description}</p>

--- a/components/sections/course/course-footer-cta.tsx
+++ b/components/sections/course/course-footer-cta.tsx
@@ -3,9 +3,9 @@ import { Button } from "@/components/ui/button"
 
 export default function CourseFooterCTA() {
   return (
-    <section className="bg-[#0f0f1c] px-6 py-16 text-center">
+    <section className="bg-section px-6 py-16 text-center">
       <div className="max-w-3xl mx-auto space-y-6">
-        <h2 className="text-2xl sm:text-3xl font-heading font-bold text-yellow-300">
+        <h2 className="text-2xl sm:text-3xl font-heading font-bold text-accent">
           You’re One Decision Away…
         </h2>
 
@@ -13,7 +13,7 @@ export default function CourseFooterCTA() {
           You can keep figuring this out alone. Or plug into a proven system and start earning today.
         </p>
 
-        <Button className="bg-yellow-400 text-black font-bold px-8 py-4 hover:scale-105 transition">
+        <Button className="bg-highlight text-black font-bold px-8 py-4 hover:scale-105 transition">
           Join Now & Start Earning Tonight
         </Button>
 

--- a/components/sections/course/course-guarantee.tsx
+++ b/components/sections/course/course-guarantee.tsx
@@ -3,10 +3,10 @@ import { ShieldCheck } from "lucide-react"
 
 export default function CourseGuarantee() {
   return (
-    <section className="bg-[#0f0f1c] px-6 py-20 text-center text-white">
+    <section className="bg-section px-6 py-20 text-center text-white">
       <div className="max-w-3xl mx-auto space-y-6">
-        <ShieldCheck className="w-10 h-10 mx-auto text-yellow-300" />
-        <h2 className="text-2xl sm:text-3xl font-heading font-bold text-yellow-300">14-Day Money Back Guarantee</h2>
+        <ShieldCheck className="w-10 h-10 mx-auto text-accent" />
+        <h2 className="text-2xl sm:text-3xl font-heading font-bold text-accent">14-Day Money Back Guarantee</h2>
         <p className="text-purple-200 text-sm">
           Try the entire course risk-free. If you don't feel it's a good fit, email us within 14 days and we'll refund your payment—no questions asked.
         </p>

--- a/components/sections/course/course-hero.tsx
+++ b/components/sections/course/course-hero.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button"
 
 export default function CourseHero() {
   return (
-    <section className="bg-[#0f0f1c] py-20 px-6">
+    <section className="bg-section py-20 px-6">
       <div className="max-w-5xl mx-auto text-center space-y-6">
         <h1 className="text-4xl sm:text-5xl font-heading font-extrabold text-white">
           Ultimate Branding Course <br /> with <span className="text-purple-400">Master Resell Rights</span>
@@ -11,7 +11,7 @@ export default function CourseHero() {
         <p className="text-lg text-purple-200 font-medium max-w-2xl mx-auto">
           Learn. Earn. Resell Forever. Build Your Digital Empire with 100% Profits, Lifetime Access, and AI-Powered Automation.
         </p>
-        <Button className="bg-yellow-400 text-black font-bold text-sm px-8 py-4 hover:scale-105 transition">
+        <Button className="bg-highlight text-black font-bold text-sm px-8 py-4 hover:scale-105 transition">
           Get Instant Access – $497
         </Button>
         <p className="text-xs text-gray-500 mt-2">One-time payment • No subscriptions • Instant access</p>

--- a/components/sections/course/course-highlights.tsx
+++ b/components/sections/course/course-highlights.tsx
@@ -13,9 +13,9 @@ const highlights = [
 
 export default function CourseHighlights() {
   return (
-    <section className="bg-[#0f0f1c] px-6 py-20">
+    <section className="bg-section px-6 py-20">
       <div className="max-w-5xl mx-auto text-center space-y-8">
-        <h2 className="text-2xl sm:text-3xl font-heading font-bold text-yellow-300">
+        <h2 className="text-2xl sm:text-3xl font-heading font-bold text-accent">
           What You'll Master
         </h2>
         <ul className="grid gap-4 text-left text-white text-sm sm:text-base max-w-3xl mx-auto">

--- a/components/sections/course/course-instructor.tsx
+++ b/components/sections/course/course-instructor.tsx
@@ -3,10 +3,10 @@ import Image from "next/image"
 
 export default function CourseInstructor() {
   return (
-    <section className="bg-[#151525] px-6 py-20 text-white">
+    <section className="bg-card px-6 py-20 text-white">
       <div className="max-w-4xl mx-auto grid md:grid-cols-2 gap-8 items-center">
         <div className="text-center md:text-left space-y-4">
-          <h2 className="text-2xl sm:text-3xl font-heading font-bold text-yellow-300">Meet Your Instructor</h2>
+          <h2 className="text-2xl sm:text-3xl font-heading font-bold text-accent">Meet Your Instructor</h2>
           <p className="text-purple-200 text-sm">
             I'm Jordan, a digital strategist with over 10 years of branding experience. I've helped hundreds of creators build profitable online businesses.
           </p>
@@ -20,7 +20,7 @@ export default function CourseInstructor() {
             alt="Instructor portrait"
             width={200}
             height={200}
-            className="rounded-full border-4 border-yellow-300"
+            className="rounded-full border-border border-accent"
           />
         </div>
       </div>

--- a/components/sections/course/course-price.tsx
+++ b/components/sections/course/course-price.tsx
@@ -3,9 +3,9 @@ import { Button } from "@/components/ui/button"
 
 export default function CoursePrice() {
   return (
-    <section className="bg-[#151525] px-6 py-20 text-center">
+    <section className="bg-card px-6 py-20 text-center">
       <div className="max-w-xl mx-auto space-y-6">
-        <h2 className="text-3xl font-heading font-bold text-yellow-300">
+        <h2 className="text-3xl font-heading font-bold text-accent">
           Lifetime Access – One Payment Only
         </h2>
 
@@ -13,10 +13,10 @@ export default function CoursePrice() {
           Get the full Ultimate Branding Course, Resell Rights, bonuses, updates, and access — forever.
         </p>
 
-        <div className="inline-block bg-[#1f1f2e] border border-[#2c2c40] px-10 py-8 rounded-xl shadow-md">
-          <p className="text-5xl font-extrabold text-yellow-400 mb-2">€497</p>
+        <div className="inline-block bg-card border border-border px-10 py-8 rounded-xl shadow-md">
+          <p className="text-5xl font-extrabold text-accent mb-2">€497</p>
           <p className="text-sm text-purple-200 mb-4 line-through">€997 regular price</p>
-          <Button className="text-black bg-yellow-400 font-bold text-sm px-8 py-4 hover:scale-105 transition">
+          <Button className="text-black bg-highlight font-bold text-sm px-8 py-4 hover:scale-105 transition">
             Get Instant Access
           </Button>
         </div>

--- a/components/sections/course/course-reasons.tsx
+++ b/components/sections/course/course-reasons.tsx
@@ -11,9 +11,9 @@ const reasons = [
 
 export default function CourseReasons() {
   return (
-    <section className="bg-[#151525] px-6 py-20">
+    <section className="bg-card px-6 py-20">
       <div className="max-w-4xl mx-auto text-center">
-        <h2 className="text-2xl sm:text-3xl font-heading font-bold text-yellow-300 mb-8">
+        <h2 className="text-2xl sm:text-3xl font-heading font-bold text-accent mb-8">
           Why Choose This Course?
         </h2>
         <ul className="grid gap-4 text-left text-white text-sm sm:text-base max-w-2xl mx-auto">

--- a/components/sections/course/course-sticky-cta.tsx
+++ b/components/sections/course/course-sticky-cta.tsx
@@ -2,9 +2,9 @@ import { Button } from "@/components/ui/button"
 
 export default function CourseStickyCTA() {
   return (
-    <div className="sticky top-0 z-20 flex justify-between items-center px-4 py-3 bg-[#151525] border-b border-[#2c2c40] shadow-md">
+    <div className="sticky top-0 z-20 flex justify-between items-center px-4 py-3 bg-card border-b border-border shadow-md">
       <p className="text-white font-semibold">Enroll today – Only €497</p>
-      <Button className="bg-yellow-400 text-black font-bold px-4 py-2">Join Now</Button>
+      <Button className="bg-highlight text-black font-bold px-4 py-2">Join Now</Button>
     </div>
   )
 }

--- a/components/sections/course/course-testimonials.tsx
+++ b/components/sections/course/course-testimonials.tsx
@@ -18,14 +18,14 @@ const testimonials = [
 
 export default function CourseTestimonials() {
   return (
-    <section className="bg-[#0f0f1c] px-6 py-20 text-center text-white">
+    <section className="bg-section px-6 py-20 text-center text-white">
       <div className="max-w-4xl mx-auto space-y-8">
-        <h2 className="text-2xl sm:text-3xl font-heading font-bold text-yellow-300">Student Success Stories</h2>
+        <h2 className="text-2xl sm:text-3xl font-heading font-bold text-accent">Student Success Stories</h2>
         <div className="grid gap-6 sm:grid-cols-3">
           {testimonials.map((t, i) => (
-            <div key={i} className="bg-[#151525] border border-[#2e2e40] p-6 rounded-xl shadow-md h-full flex flex-col justify-between">
+            <div key={i} className="bg-card border border-border p-6 rounded-xl shadow-md h-full flex flex-col justify-between">
               <p className="text-purple-200 text-sm mb-4 flex-1">"{t.quote}"</p>
-              <div className="flex items-center justify-center gap-2 text-yellow-300 text-sm font-medium">
+              <div className="flex items-center justify-center gap-2 text-accent text-sm font-medium">
                 <Quote className="w-4 h-4" />
                 <span>{t.name}</span>
               </div>

--- a/components/sections/freebie.tsx
+++ b/components/sections/freebie.tsx
@@ -31,9 +31,9 @@ export default function FreebieSection() {
   }
 
   return (
-    <section className="bg-[#151525] px-6 py-16 text-white mt-12">
+    <section className="bg-section px-6 py-16 text-white mt-12">
       <div className="max-w-xl mx-auto space-y-6 text-center">
-        <h2 className="text-2xl font-heading font-bold text-yellow-300">
+        <h2 className="text-2xl font-heading font-bold text-accent">
           {freeProduct.title}
         </h2>
         <p className="text-purple-200 text-sm">{freeProduct.description}</p>
@@ -44,19 +44,19 @@ export default function FreebieSection() {
             placeholder="Your email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="w-full px-4 py-2 rounded-md bg-[#2c2c40] text-white placeholder-gray-400"
+            className="w-full px-4 py-2 rounded-md bg-card text-white placeholder-gray-400"
           />
           <input
             type="tel"
             placeholder="Phone (optional)"
             value={phone}
             onChange={(e) => setPhone(e.target.value)}
-            className="w-full px-4 py-2 rounded-md bg-[#2c2c40] text-white placeholder-gray-400"
+            className="w-full px-4 py-2 rounded-md bg-card text-white placeholder-gray-400"
           />
           <button
             type="submit"
             disabled={loading}
-            className="bg-yellow-400 text-black font-bold px-6 py-3 rounded-md hover:scale-105 transition w-full"
+            className="bg-highlight text-black font-bold px-6 py-3 rounded-md hover:scale-105 transition w-full"
           >
             {loading ? 'Sending...' : freeProduct.ctaLabel}
           </button>

--- a/components/sections/hero.tsx
+++ b/components/sections/hero.tsx
@@ -40,7 +40,7 @@ export default function HeroSection() {
 
 
   return (
-    <section className="bg-[#0f0f1c] border-b border-[#1f1f2e] px-6 py-20 rounded-b-2xl max-w-6xl mx-auto shadow-lg relative">
+    <section className="bg-section border-b border-border px-6 py-20 rounded-b-2xl shadow-lg relative">
       {/* <section className="bg-[#232336] border-b border-[#2a2a3a] shadow-lg rounded-b-2xl"> */}
 
 
@@ -52,14 +52,14 @@ export default function HeroSection() {
           <p className="text-accent text-lg font-medium mb-6">
             AI POWER. SOUL-DRIVEN IMPACT.<br /> ENROLL INSTANTLY.
           </p>
-          <Button className="bg-yellow-400 hover:bg-yellow-300 text-black font-bold px-6 py-2 rounded-md">Get Started</Button>
+          <Button className="bg-highlight text-black font-bold px-6 py-2 rounded-md">Get Started</Button>
         </div>
 
         {/* <div className="absolute top-6 right-6 bg-[#1f1f2e] text-sm text-white px-4 py-3 rounded-lg shadow-md">
           <p className="font-semibold mb-1">Hello</p>
           <p className="text-xs text-text-soft">How can I help you?</p>
         </div> */}
-        <div className="absolute top-6 right-6 bg-[#1f1f2e] text-sm text-white p-4 rounded-lg shadow-md w-72">
+        <div className="absolute top-6 right-6 bg-card text-sm text-white p-4 rounded-lg shadow-md w-72">
           <div className="h-40 overflow-y-auto space-y-2 mb-2 text-xs">
             {messages.length === 0 && (
               <p className="text-text-soft">How can I help you?</p>
@@ -76,7 +76,7 @@ export default function HeroSection() {
               value={input}
               onChange={(e) => setInput(e.target.value)}
               placeholder="Ask the AI..."
-              className="flex-grow rounded-md bg-[#2c2c40] px-2 py-1 text-white placeholder-gray-400"
+              className="flex-grow rounded-md bg-card px-2 py-1 text-white placeholder-gray-400"
             />
             <Button type="submit" disabled={loading} className="px-3 py-1 text-xs">
               {loading ? "..." : "Send"}

--- a/components/sections/lifetime-access.tsx
+++ b/components/sections/lifetime-access.tsx
@@ -3,15 +3,15 @@ import { Button } from "@/components/ui/button"
 
 export default function LifetimeAccess() {
   return (
-    <section className="bg-[#151525] px-6 py-20 text-center text-white max-w-4xl mx-auto rounded-xl mt-12 shadow-lg">
-      <h2 className="text-3xl font-heading font-extrabold text-yellow-300 mb-4">
+    <section className="bg-section px-6 py-20 text-center text-white max-w-4xl mx-auto rounded-xl mt-12 shadow-lg">
+      <h2 className="text-3xl font-heading font-extrabold text-accent mb-4">
         Get Lifetime Access
       </h2>
       <p className="text-purple-300 mb-6 text-lg">
         Unlock all courses, templates, and future updates — one-time payment.
       </p>
-      <div className="inline-block bg-[#1f1f2e] border border-[#2c2c40] px-8 py-6 rounded-xl">
-        <p className="text-4xl font-bold text-yellow-400 mb-2">€497</p>
+      <div className="inline-block bg-card border border-border px-8 py-6 rounded-xl">
+        <p className="text-4xl font-bold text-accent mb-2">€497</p>
         <p className="text-sm text-purple-200 mb-4 line-through">€997 regular price</p>
         <Button>Buy Now</Button>
       </div>

--- a/components/sections/products.tsx
+++ b/components/sections/products.tsx
@@ -6,7 +6,7 @@ export default function ProductsSection() {
   const paid = Object.values(products).filter(p => !p.isFree && p.category === 'product')
 
   return (
-    <section className="bg-[#0f0f1c] px-6 py-20">
+    <section className="bg-section px-6 py-20">
       <div className="max-w-6xl mx-auto">
         <h2 className="text-xl text-white font-semibold mb-6">💸 Premium Products</h2>
         <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-8">
@@ -14,16 +14,16 @@ export default function ProductsSection() {
             <Link
               key={prod.slug}
               href={`/products/${prod.slug}`}
-              className="block bg-[#151525] border border-[#2c2c40] p-6 rounded-xl shadow-md space-y-4 hover:shadow-xl transition-all duration-200"
+              className="block bg-card border border-border p-6 rounded-xl shadow-md space-y-4 hover:shadow-xl transition-all duration-200"
             >
               <img
                 src={prod.image}
                 alt={prod.title}
-                className="w-full rounded-lg border border-[#2c2c40]"
+                className="w-full rounded-lg border border-border"
               />
               <h3 className="text-xl font-bold text-white">{prod.title}</h3>
               <p className="text-purple-200 text-sm">{prod.description}</p>
-              <span className="inline-flex items-center gap-2 text-yellow-300 text-sm font-medium hover:underline">
+              <span className="inline-flex items-center gap-2 text-accent text-sm font-medium hover:underline">
                 Read More <ArrowRight className="w-4 h-4" />
               </span>
             </Link>

--- a/components/sections/testimonials.tsx
+++ b/components/sections/testimonials.tsx
@@ -9,14 +9,14 @@ export default function TestimonialsSection() {
     { name: 'Noah S.', quote: 'My business is thriving thanks to these tips.' },
   ]
   return (
-    <section className="bg-[#0f0f1c] px-6 py-20">
+    <section className="bg-section px-6 py-20">
       <div className="max-w-4xl mx-auto">
         <h2 className="text-xl text-white font-semibold mb-6 text-center">What creators say</h2>
         <div className="grid sm:grid-cols-3 gap-6 text-sm text-purple-200">
           {items.map((t, i) => (
-            <div key={i} className="bg-[#151525] p-4 rounded-lg border border-[#2c2c40] text-center">
+            <div key={i} className="bg-card p-4 rounded-lg border border-border text-center">
               <p className="mb-2">“{t.text}”</p>
-              <p className="text-yellow-300 font-medium">— {t.name}</p>
+              <p className="text-accent font-medium">— {t.name}</p>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- add theme context provider
- update layout to wrap with theme provider
- style updates using CSS variables
- add dropdowns in header for theme, layout and animation
- update sections to use new variables

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: 403 downloading ngrok)*

------
https://chatgpt.com/codex/tasks/task_e_685ac703ffc08330a67205c5e7a1ad81