### PR TITLE
Fix metadata by moving root layout to server component

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,9 @@
-"use client"
 // app/layout.tsx
 import "./globals.css"
 import { Inter, Space_Grotesk } from "next/font/google"
 import type { Metadata } from "next"
-import Header from "@/components/layout/header"
-import { Toaster } from "react-hot-toast"
+import Providers from "@/components/layout/providers"
+import BodyWrapper from "@/components/layout/body-wrapper"
 
 const inter = Inter({
   subsets: ["latin"],
@@ -17,38 +16,9 @@ const spaceGrotesk = Space_Grotesk({
   display: "swap",
 })
 
-export let metadata: Metadata = {
+export const metadata: Metadata = {
   title: "June — The Ultimate Branding Course",
   description: "A premium digital shop offering AI-powered marketing tips, branding guides, and expert ebooks.",
-}
-
-import { ThemeProvider, useTheme } from "@/components/context/theme-context"
-
-function BodyWrapper({ children }: { children: React.ReactNode }) {
-  const { theme, layout, animation } = useTheme()
-  return (
-    <body
-      className={`
-        ${inter.variable} ${spaceGrotesk.variable}
-        font-sans text-white theme-${theme} layout-${layout}
-      `}
-    >
-      <div className={`relative group ${layout === "wide" ? "" : "max-w-6xl mx-auto"}`}>        
-        <Header />
-        <Toaster position="top-center" />
-        {process.env.DUMMY_PAYMENT_MODE === "true" && (
-          <div className="bg-red-600 text-center text-sm py-2">
-            Payments are simulated for testing. No real transaction is made.
-          </div>
-        )}
-
-        {/* App content */}
-        <main className={animation === "fade" ? "animate-fade" : "animate-slide"}>
-          {children}
-        </main>
-      </div>
-    </body>
-  )
 }
 
 export default function RootLayout({
@@ -56,11 +26,12 @@ export default function RootLayout({
 }: {
   children: React.ReactNode
 }) {
+  const fonts = `${inter.variable} ${spaceGrotesk.variable}`
   return (
     <html lang="en" className="dark">
-      <ThemeProvider>
-        <BodyWrapper>{children}</BodyWrapper>
-      </ThemeProvider>
+      <Providers>
+        <BodyWrapper fonts={fonts}>{children}</BodyWrapper>
+      </Providers>
     </html>
   )
 }

--- a/components/layout/body-wrapper.tsx
+++ b/components/layout/body-wrapper.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import Header from '@/components/layout/header'
+import { Toaster } from 'react-hot-toast'
+import { useTheme } from '@/components/context/theme-context'
+
+export default function BodyWrapper({
+  children,
+  fonts,
+}: {
+  children: React.ReactNode
+  fonts: string
+}) {
+  const { theme, layout, animation } = useTheme()
+
+  return (
+    <body className={`${fonts} font-sans text-white theme-${theme} layout-${layout}`}>
+      <div className={`relative group ${layout === 'wide' ? '' : 'max-w-6xl mx-auto'}`}>
+        <Header />
+        <Toaster position="top-center" />
+        {process.env.DUMMY_PAYMENT_MODE === 'true' && (
+          <div className="bg-red-600 text-center text-sm py-2">
+            Payments are simulated for testing. No real transaction is made.
+          </div>
+        )}
+        <main className={animation === 'fade' ? 'animate-fade' : 'animate-slide'}>
+          {children}
+        </main>
+      </div>
+    </body>
+  )
+}

--- a/components/layout/providers.tsx
+++ b/components/layout/providers.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { ThemeProvider } from '@/components/context/theme-context'
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  return <ThemeProvider>{children}</ThemeProvider>
+}


### PR DESCRIPTION
## Summary
- move `metadata` export into a server component
- add `Providers` and `BodyWrapper` client components for theme & layout

## Testing
- `npm run lint` *(fails: next not found because deps not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6869612206cc8330abbcaf499aa6108c