### PR TITLE
Introduce db package for prisma

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Generate Prisma Client
+        run: pnpm db:generate
       - name: Lint, test, build
-        run: pnpm turbo run lint test build --filter=!packages/*
+        run: pnpm turbo run lint test build --filter=!packages/ui --filter=!packages/server
       - name: Lighthouse budget check
         run: pnpm lighthouse-ci http://localhost:3000 --budget-path=.lighthousebudget.json

--- a/app/admin/emails/page.tsx
+++ b/app/admin/emails/page.tsx
@@ -1,4 +1,4 @@
-import { prisma } from '@/lib/prisma'
+import { prisma } from 'db/client'
 import { products } from '@/lib/products'
 import Link from 'next/link'
 import RetryButton from './RetryButton'

--- a/app/api/admin/email-logs/route.ts
+++ b/app/api/admin/email-logs/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { prisma } from "@/lib/prisma"
+import { prisma } from "db/client"
 import { cookies } from "next/headers"
 
 export async function GET(req: Request) {

--- a/app/api/admin/email-queue/route.ts
+++ b/app/api/admin/email-queue/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
+import { prisma } from "db/client";
 import { cookies } from "next/headers";
 
 export async function GET(req: Request) {

--- a/app/api/admin/manual-email/route.ts
+++ b/app/api/admin/manual-email/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
+import { prisma } from "db/client";
 import { Resend } from "resend";
 import { cookies } from "next/headers";
 

--- a/app/api/admin/purchases/route.ts
+++ b/app/api/admin/purchases/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { prisma } from "@/lib/prisma"
+import { prisma } from "db/client"
 import { cookies } from "next/headers"
 
 export async function GET(req: Request) {

--- a/app/api/admin/retry-all/route.ts
+++ b/app/api/admin/retry-all/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
+import { prisma } from "db/client";
 import { sendEmailByType } from "@/lib/email";
 import { cookies } from "next/headers";
 

--- a/app/api/admin/retry-email/route.ts
+++ b/app/api/admin/retry-email/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
+import { prisma } from "db/client";
 import { sendEmailByType } from "@/lib/email";
 import { cookies } from "next/headers";
 

--- a/app/api/admin/send-email/route.ts
+++ b/app/api/admin/send-email/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { prisma } from "@/lib/prisma"
+import { prisma } from "db/client"
 import { sendCustomEmail } from "@/lib/email"
 import { cookies } from "next/headers"
 

--- a/app/api/test-email/route.ts
+++ b/app/api/test-email/route.ts
@@ -1,7 +1,7 @@
 // /app/api/send-bulk-email/route.ts
 
 import { Resend } from "resend";
-import { prisma } from "@/lib/prisma";
+import { prisma } from "db/client";
 
 
 const i = 'icloud.com';

--- a/docs/db.md
+++ b/docs/db.md
@@ -1,0 +1,10 @@
+# Database Package
+
+`packages/db` contains the Prisma schema and client. Use these commands during development:
+
+```bash
+pnpm db:migrate   # create and apply migrations
+pnpm db:generate  # regenerate the Prisma client
+```
+
+To roll back a migration, run `prisma migrate reset --schema packages/db/prisma/schema.prisma` and then re-apply with `pnpm db:migrate`.

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,6 +1,6 @@
 import { Resend } from "resend";
 import { products } from "@/lib/products";
-import { prisma } from "@/lib/prisma";
+import { prisma } from "db/client";
 
 type EmailType = "freebie" | "ebook" | "bundle" | "course" | "ai";
 

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,4 +1,0 @@
-// lib/prisma.ts
-import { PrismaClient } from "@prisma/client"
-
-export const prisma = new PrismaClient()

--- a/lib/purchase.ts
+++ b/lib/purchase.ts
@@ -1,4 +1,4 @@
-import { prisma } from "@/lib/prisma";
+import { prisma } from "db/client";
 import { sendEmailByType } from "@/lib/email";
 
 export async function logPurchase(email: string, slug: string, opts?: { name?: string; phone?: string }) {

--- a/package.json
+++ b/package.json
@@ -8,10 +8,13 @@
     "start": "next start",
     "lint": "next lint",
     "move-to-packages": "ts-node scripts/move-to-packages.ts",
-    "test": "playwright test"
+    "test": "playwright test",
+    "db:generate": "prisma generate --schema packages/db/prisma/schema.prisma",
+    "db:migrate": "prisma migrate dev --schema packages/db/prisma/schema.prisma",
+    "postinstall": "pnpm db:generate"
   },
   "dependencies": {
-    "@prisma/client": "^6.10.1",
+    "@prisma/client": "6.11.1",
     "@tailwindcss/typography": "^0.5.16",
     "clsx": "^2.1.1",
     "lucide-react": "^0.515.0",
@@ -34,7 +37,7 @@
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.5",
     "prettier": "3.6.0",
-    "prisma": "^6.10.1",
+    "prisma": "6.11.1",
     "tailwindcss": "^4.1.10",
     "typescript": "^5",
     "@playwright/test": "^1.44.0"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@acme/db",
+  "version": "0.0.0",
+  "private": true,
+  "publishConfig": { "private": true },
+  "exports": "./src"
+}

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -5,6 +5,8 @@ datasource db {
 
 generator client {
   provider = "prisma-client-js"
+  output   = "../../node_modules/.prisma/db"
+  previewFeatures = ["driverAdapters"]
 }
 
 model Purchase {

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,0 +1,8 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ?? new PrismaClient().$extends({});
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,2 @@
+export * from "@prisma/client";
+export { prisma } from "./client";

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@prisma/client':
-        specifier: ^6.10.1
-        version: 6.10.1(prisma@6.10.1(typescript@5.8.3))(typescript@5.8.3)
+        specifier: 6.11.1
+        version: 6.11.1(prisma@6.11.1(typescript@5.8.3))(typescript@5.8.3)
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@4.1.10)
@@ -76,14 +76,16 @@ importers:
         specifier: 3.6.0
         version: 3.6.0
       prisma:
-        specifier: ^6.10.1
-        version: 6.10.1(typescript@5.8.3)
+        specifier: 6.11.1
+        version: 6.11.1(typescript@5.8.3)
       tailwindcss:
         specifier: ^4.1.10
         version: 4.1.10
       typescript:
         specifier: ^5
         version: 5.8.3
+
+  packages/db: {}
 
   packages/server: {}
 
@@ -296,8 +298,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@prisma/client@6.10.1':
-    resolution: {integrity: sha512-Re4pMlcUsQsUTAYMK7EJ4Bw2kg3WfZAAlr8GjORJaK4VOP6LxRQUQ1TuLnxcF42XqGkWQ36q5CQF1yVadANQ6w==}
+  '@prisma/client@6.11.1':
+    resolution: {integrity: sha512-5CLFh8QP6KxRm83pJ84jaVCeSVPQr8k0L2SEtOJHwdkS57/VQDcI/wQpGmdyOZi+D9gdNabdo8tj1Uk+w+upsQ==}
     engines: {node: '>=18.18'}
     peerDependencies:
       prisma: '*'
@@ -308,23 +310,23 @@ packages:
       typescript:
         optional: true
 
-  '@prisma/config@6.10.1':
-    resolution: {integrity: sha512-kz4/bnqrOrzWo8KzYguN0cden4CzLJJ+2VSpKtF8utHS3l1JS0Lhv6BLwpOX6X9yNreTbZQZwewb+/BMPDCIYQ==}
+  '@prisma/config@6.11.1':
+    resolution: {integrity: sha512-z6rCTQN741wxDq82cpdzx2uVykpnQIXalLhrWQSR0jlBVOxCIkz3HZnd8ern3uYTcWKfB3IpVAF7K2FU8t/8AQ==}
 
-  '@prisma/debug@6.10.1':
-    resolution: {integrity: sha512-k2YT53cWxv9OLjW4zSYTZ6Z7j0gPfCzcr2Mj99qsuvlxr8WAKSZ2NcSR0zLf/mP4oxnYG842IMj3utTgcd7CaA==}
+  '@prisma/debug@6.11.1':
+    resolution: {integrity: sha512-lWRb/YSWu8l4Yum1UXfGLtqFzZkVS2ygkWYpgkbgMHn9XJlMITIgeMvJyX5GepChzhmxuSuiq/MY/kGFweOpGw==}
 
-  '@prisma/engines-version@6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c':
-    resolution: {integrity: sha512-ZJFTsEqapiTYVzXya6TUKYDFnSWCNegfUiG5ik9fleQva5Sk3DNyyUi7X1+0ZxWFHwHDr6BZV5Vm+iwP+LlciA==}
+  '@prisma/engines-version@6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9':
+    resolution: {integrity: sha512-swFJTOOg4tHyOM1zB/pHb3MeH0i6t7jFKn5l+ZsB23d9AQACuIRo9MouvuKGvnDogzkcjbWnXi/NvOZ0+n5Jfw==}
 
-  '@prisma/engines@6.10.1':
-    resolution: {integrity: sha512-Q07P5rS2iPwk2IQr/rUQJ42tHjpPyFcbiH7PXZlV81Ryr9NYIgdxcUrwgVOWVm5T7ap02C0dNd1dpnNcSWig8A==}
+  '@prisma/engines@6.11.1':
+    resolution: {integrity: sha512-6eKEcV6V8W2eZAUwX2xTktxqPM4vnx3sxz3SDtpZwjHKpC6lhOtc4vtAtFUuf5+eEqBk+dbJ9Dcaj6uQU+FNNg==}
 
-  '@prisma/fetch-engine@6.10.1':
-    resolution: {integrity: sha512-clmbG/Jgmrc/n6Y77QcBmAUlq9LrwI9Dbgy4pq5jeEARBpRCWJDJ7PWW1P8p0LfFU0i5fsyO7FqRzRB8mkdS4g==}
+  '@prisma/fetch-engine@6.11.1':
+    resolution: {integrity: sha512-NBYzmkXTkj9+LxNPRSndaAeALOL1Gr3tjvgRYNqruIPlZ6/ixLeuE/5boYOewant58tnaYFZ5Ne0jFBPfGXHpQ==}
 
-  '@prisma/get-platform@6.10.1':
-    resolution: {integrity: sha512-4CY5ndKylcsce9Mv+VWp5obbR2/86SHOLVV053pwIkhVtT9C9A83yqiqI/5kJM9T1v1u1qco/bYjDKycmei9HA==}
+  '@prisma/get-platform@6.11.1':
+    resolution: {integrity: sha512-b2Z8oV2gwvdCkFemBTFd0x4lsL4O2jLSx8lB7D+XqoFALOQZPa7eAPE1NU0Mj1V8gPHRxIsHnyUNtw2i92psUw==}
 
   '@react-email/render@1.1.2':
     resolution: {integrity: sha512-RnRehYN3v9gVlNMehHPHhyp2RQo7+pSkHDtXPvg3s0GbzM9SQMW4Qrf8GRNvtpLC4gsI+Wt0VatNRUFqjvevbw==}
@@ -951,8 +953,8 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  prisma@6.10.1:
-    resolution: {integrity: sha512-khhlC/G49E4+uyA3T3H5PRBut486HD2bDqE2+rvkU0pwk9IAqGFacLFUyIx9Uw+W2eCtf6XGwsp+/strUwMNPw==}
+  prisma@6.11.1:
+    resolution: {integrity: sha512-VzJToRlV0s9Vu2bfqHiRJw73hZNCG/AyJeX+kopbu4GATTjTUdEWUteO3p4BLYoHpMS4o8pD3v6tF44BHNZI1w==}
     engines: {node: '>=18.18'}
     hasBin: true
     peerDependencies:
@@ -1288,35 +1290,35 @@ snapshots:
     dependencies:
       playwright: 1.53.2
 
-  '@prisma/client@6.10.1(prisma@6.10.1(typescript@5.8.3))(typescript@5.8.3)':
+  '@prisma/client@6.11.1(prisma@6.11.1(typescript@5.8.3))(typescript@5.8.3)':
     optionalDependencies:
-      prisma: 6.10.1(typescript@5.8.3)
+      prisma: 6.11.1(typescript@5.8.3)
       typescript: 5.8.3
 
-  '@prisma/config@6.10.1':
+  '@prisma/config@6.11.1':
     dependencies:
       jiti: 2.4.2
 
-  '@prisma/debug@6.10.1': {}
+  '@prisma/debug@6.11.1': {}
 
-  '@prisma/engines-version@6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c': {}
+  '@prisma/engines-version@6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9': {}
 
-  '@prisma/engines@6.10.1':
+  '@prisma/engines@6.11.1':
     dependencies:
-      '@prisma/debug': 6.10.1
-      '@prisma/engines-version': 6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c
-      '@prisma/fetch-engine': 6.10.1
-      '@prisma/get-platform': 6.10.1
+      '@prisma/debug': 6.11.1
+      '@prisma/engines-version': 6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9
+      '@prisma/fetch-engine': 6.11.1
+      '@prisma/get-platform': 6.11.1
 
-  '@prisma/fetch-engine@6.10.1':
+  '@prisma/fetch-engine@6.11.1':
     dependencies:
-      '@prisma/debug': 6.10.1
-      '@prisma/engines-version': 6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c
-      '@prisma/get-platform': 6.10.1
+      '@prisma/debug': 6.11.1
+      '@prisma/engines-version': 6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9
+      '@prisma/get-platform': 6.11.1
 
-  '@prisma/get-platform@6.10.1':
+  '@prisma/get-platform@6.11.1':
     dependencies:
-      '@prisma/debug': 6.10.1
+      '@prisma/debug': 6.11.1
 
   '@react-email/render@1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -1915,10 +1917,10 @@ snapshots:
 
   prettier@3.6.0: {}
 
-  prisma@6.10.1(typescript@5.8.3):
+  prisma@6.11.1(typescript@5.8.3):
     dependencies:
-      '@prisma/config': 6.10.1
-      '@prisma/engines': 6.10.1
+      '@prisma/config': 6.11.1
+      '@prisma/engines': 6.11.1
     optionalDependencies:
       typescript: 5.8.3
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -34,6 +34,9 @@
       ],
       "server/*": [
         "packages/server/src/*"
+      ],
+      "db/*": [
+        "packages/db/src/*"
       ]
     },
     "baseUrl": "."


### PR DESCRIPTION
## Summary
- move schema under packages/db and add prisma client singleton
- codemod imports to use `db/client`
- bump Prisma to 6.11.1 and expose db scripts
- wire db generation into CI and update tsconfig path
- document migration workflow

## Testing
- `pnpm lint` *(fails: Next.js prompted ESLint config)*
- `pnpm test` *(fails: missing Playwright browsers)*
- `pnpm build` *(fails: failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68697c30c79c8330af119a7ec5c310ce